### PR TITLE
Move `XorShiftRng` from the main repo

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,3 @@
-The Small RNGs project is part of the Rand project.
-
 Copyrights in the Rand project are retained by their contributors. No
 copyright assignment is required to contribute to the Rand project.
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,5 @@
 Copyright 2018 Developers of the Rand project
+Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/rand_xorshift/CHANGELOG.md
+++ b/rand_xorshift/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2018-07-16
+- Initial release

--- a/rand_xorshift/COPYRIGHT
+++ b/rand_xorshift/COPYRIGHT
@@ -1,0 +1,12 @@
+Copyrights in the Rand project are retained by their contributors. No
+copyright assignment is required to contribute to the Rand project.
+
+For full authorship information, see the version control history.
+
+Except as otherwise noted (below and/or in individual files), Rand is
+licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
+<http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+<LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
+
+The Rand project includes code from the Rust project
+published under these same licenses.

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "rand_xorshift"
+version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+authors = ["The Rand Project Developers", "The Rust Project Developers"]
+license = "MIT/Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/rust-random/rand"
+documentation = "https://docs.rs/rand_isaac"
+homepage = "https://crates.io/crates/rand_isaac"
+description = """
+Xorshift random number generator
+"""
+keywords = ["random", "rng", "xorshift"]
+categories = ["algorithms", "no-std"]
+
+[badges]
+travis-ci = { repository = "rust-random/rand" }
+appveyor = { repository = "dhardy/rand" }
+
+[features]
+serde1 = ["serde", "serde_derive"]
+
+[dependencies]
+rand_core = { path = "../rand_core", version = ">=0.2, <0.4", default-features=false }
+serde = { version = "1", optional = true }
+serde_derive = { version = "^1.0.38", optional = true }
+
+[dev-dependencies]
+# This is for testing serde, unfortunately we can't specify feature-gated dev
+# deps yet, see: https://github.com/rust-lang/cargo/issues/1596
+bincode = "1"

--- a/rand_xorshift/LICENSE-APACHE
+++ b/rand_xorshift/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rand_xorshift/LICENSE-MIT
+++ b/rand_xorshift/LICENSE-MIT
@@ -1,0 +1,26 @@
+Copyright 2018 Developers of the Rand project
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rand_xorshift/README.md
+++ b/rand_xorshift/README.md
@@ -1,7 +1,7 @@
 # rand_xorshift
 
-[![Build Status](https://travis-ci.org/rust-random/rand.svg)](https://travis-ci.org/rust-random/rand)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/dhardy/rand)
+[![Build Status](https://travis-ci.org/rust-random/small-rngs.svg?branch=master)](https://travis-ci.org/rust-random/small-rngs)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/small-rngs?svg=true)](https://ci.appveyor.com/project/rust-random/small-rngs)
 [![Latest version](https://img.shields.io/crates/v/rand_xorshift.svg)](https://crates.io/crates/rand_xorshift)
 [![Documentation](https://docs.rs/rand_xorshift/badge.svg)](https://docs.rs/rand_xorshift)
 [![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)

--- a/rand_xorshift/README.md
+++ b/rand_xorshift/README.md
@@ -1,0 +1,44 @@
+# rand_xorshift
+
+[![Build Status](https://travis-ci.org/rust-random/rand.svg)](https://travis-ci.org/rust-random/rand)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/dhardy/rand)
+[![Latest version](https://img.shields.io/crates/v/rand_xorshift.svg)](https://crates.io/crates/rand_xorshift)
+[![Documentation](https://docs.rs/rand_xorshift/badge.svg)](https://docs.rs/rand_xorshift)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![License](https://img.shields.io/crates/l/rand_xorshift.svg)](https://github.com/rust-random/rand/tree/master/rand_xorshift#license)
+
+Implements the Xorshift random number generator.
+
+The Xorshift[^1] algorithm is not suitable for cryptographic purposes
+but is very fast. If you do not know for sure that it fits your
+requirements, use a more secure one such as `StdRng` or `OsRng`.
+
+[^1]: Marsaglia, George (July 2003).
+      ["Xorshift RNGs"](https://www.jstatsoft.org/v08/i14/paper).
+      *Journal of Statistical Software*. Vol. 8 (Issue 14).
+
+Documentation:
+[master branch](https://rust-random.github.io/rand/rand_xorshift/index.html),
+[by release](https://docs.rs/rand_isaac)
+
+[Changelog](CHANGELOG.md)
+
+[rand]: https://crates.io/crates/rand
+
+
+## Crate Features
+
+`rand_xorshift` is `no_std` compatible. It does not require any functionality
+outside of the `core` lib, thus there are no features to configure.
+
+The `serde1` feature includes implementations of `Serialize` and `Deserialize`
+for the included RNGs.
+
+
+## License
+
+`rand_xorshift` is distributed under the terms of both the MIT license and the
+Apache License (Version 2.0).
+
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT), and
+[COPYRIGHT](COPYRIGHT) for details.

--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The xorshift random number generator.
+
+#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
+       html_favicon_url = "https://www.rust-lang.org/favicon.ico",
+       html_root_url = "https://docs.rs/rand_xorshift/0.1.0")]
+
+#![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
+#![doc(test(attr(allow(unused_variables), deny(warnings))))]
+
+#![cfg_attr(not(all(feature="serde1", test)), no_std)]
+
+extern crate rand_core;
+
+#[cfg(feature="serde1")] extern crate serde;
+#[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
+
+// To test serialization we need bincode and the standard library
+#[cfg(all(feature="serde1", test))] extern crate bincode;
+#[cfg(all(feature="serde1", test))] extern crate std as core;
+
+mod xorshift;
+
+pub use self::xorshift::XorShiftRng;

--- a/rand_xorshift/src/xorshift.rs
+++ b/rand_xorshift/src/xorshift.rs
@@ -1,0 +1,206 @@
+// Copyright 2018 Developers of the Rand project.
+// Copyright 2017 The Rust Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Xorshift generators
+
+use core::num::Wrapping as w;
+use core::{fmt, slice};
+use rand_core::{RngCore, SeedableRng, Error, impls, le};
+
+/// An Xorshift random number generator.
+///
+/// The Xorshift[^1] algorithm is not suitable for cryptographic purposes
+/// but is very fast. If you do not know for sure that it fits your
+/// requirements, use a more secure one such as `StdRng` or `OsRng`.
+///
+/// [^1]: Marsaglia, George (July 2003).
+///       ["Xorshift RNGs"](https://www.jstatsoft.org/v08/i14/paper).
+///       *Journal of Statistical Software*. Vol. 8 (Issue 14).
+#[derive(Clone)]
+#[cfg_attr(feature="serde1", derive(Serialize,Deserialize))]
+pub struct XorShiftRng {
+    x: w<u32>,
+    y: w<u32>,
+    z: w<u32>,
+    w: w<u32>,
+}
+
+// Custom Debug implementation that does not expose the internal state
+impl fmt::Debug for XorShiftRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "XorShiftRng {{}}")
+    }
+}
+
+impl RngCore for XorShiftRng {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        let x = self.x;
+        let t = x ^ (x << 11);
+        self.x = self.y;
+        self.y = self.z;
+        self.z = self.w;
+        let w_ = self.w;
+        self.w = w_ ^ (w_ >> 19) ^ (t ^ (t >> 8));
+        self.w.0
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        impls::next_u64_via_u32(self)
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_next(self, dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
+    }
+}
+
+impl SeedableRng for XorShiftRng {
+    type Seed = [u8; 16];
+
+    fn from_seed(seed: Self::Seed) -> Self {
+        let mut seed_u32 = [0u32; 4];
+        le::read_u32_into(&seed, &mut seed_u32);
+
+        // Xorshift cannot be seeded with 0 and we cannot return an Error, but
+        // also do not wish to panic (because a random seed can legitimately be
+        // 0); our only option is therefore to use a preset value.
+        if seed_u32.iter().all(|&x| x == 0) {
+            seed_u32 = [0xBAD_5EED, 0xBAD_5EED, 0xBAD_5EED, 0xBAD_5EED];
+        }
+
+        XorShiftRng {
+            x: w(seed_u32[0]),
+            y: w(seed_u32[1]),
+            z: w(seed_u32[2]),
+            w: w(seed_u32[3]),
+        }
+    }
+
+    fn from_rng<R: RngCore>(mut rng: R) -> Result<Self, Error> {
+        let mut seed_u32 = [0u32; 4];
+        loop {
+            unsafe {
+                let ptr = seed_u32.as_mut_ptr() as *mut u8;
+
+                let slice = slice::from_raw_parts_mut(ptr, 4 * 4);
+                rng.try_fill_bytes(slice)?;
+            }
+            if !seed_u32.iter().all(|&x| x == 0) { break; }
+        }
+
+        Ok(XorShiftRng {
+            x: w(seed_u32[0]),
+            y: w(seed_u32[1]),
+            z: w(seed_u32[2]),
+            w: w(seed_u32[3]),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ::rand_core::{RngCore, SeedableRng};
+    use super::XorShiftRng;
+
+    #[test]
+    fn test_xorshift_construction() {
+        // Test that various construction techniques produce a working RNG.
+        let seed = [1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16];
+        let mut rng1 = XorShiftRng::from_seed(seed);
+        assert_eq!(rng1.next_u64(), 4325440999699518727);
+
+        let _rng2 = XorShiftRng::from_rng(rng1).unwrap();
+        // Note: we cannot test the state of _rng2 because from_rng does not
+        // fix Endianness. This is allowed in the trait specification.
+    }
+
+    #[test]
+    fn test_xorshift_true_values() {
+        let seed = [16,15,14,13, 12,11,10,9, 8,7,6,5, 4,3,2,1];
+        let mut rng = XorShiftRng::from_seed(seed);
+
+        let mut results = [0u32; 9];
+        for i in results.iter_mut() { *i = rng.next_u32(); }
+        let expected: [u32; 9] = [
+            2081028795, 620940381, 269070770, 16943764, 854422573, 29242889,
+            1550291885, 1227154591, 271695242];
+        assert_eq!(results, expected);
+
+        let mut results = [0u64; 9];
+        for i in results.iter_mut() { *i = rng.next_u64(); }
+        let expected: [u64; 9] = [
+            9247529084182843387, 8321512596129439293, 14104136531997710878,
+            6848554330849612046, 343577296533772213, 17828467390962600268,
+            9847333257685787782, 7717352744383350108, 1133407547287910111];
+        assert_eq!(results, expected);
+
+        let mut results = [0u8; 32];
+        rng.fill_bytes(&mut results);
+        let expected = [102, 57, 212, 16, 233, 130, 49, 183,
+                        158, 187, 44, 203, 63, 149, 45, 17,
+                        117, 129, 131, 160, 70, 121, 158, 155,
+                        224, 209, 192, 53, 10, 62, 57, 72];
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn test_xorshift_zero_seed() {
+        // Xorshift does not work with an all zero seed.
+        // Assert it does not panic.
+        let seed = [0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0];
+        let mut rng = XorShiftRng::from_seed(seed);
+        let a = rng.next_u64();
+        let b = rng.next_u64();
+        assert!(a != 0);
+        assert!(b != a);
+    }
+
+    #[test]
+    fn test_xorshift_clone() {
+        let seed = [1,2,3,4, 5,5,7,8, 8,7,6,5, 4,3,2,1];
+        let mut rng1 = XorShiftRng::from_seed(seed);
+        let mut rng2 = rng1.clone();
+        for _ in 0..16 {
+            assert_eq!(rng1.next_u64(), rng2.next_u64());
+        }
+    }
+
+    #[cfg(feature="serde1")]
+    #[test]
+    fn test_xorshift_serde() {
+        use bincode;
+        use std::io::{BufWriter, BufReader};
+
+        let seed = [1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16];
+        let mut rng = XorShiftRng::from_seed(seed);
+
+        let buf: Vec<u8> = Vec::new();
+        let mut buf = BufWriter::new(buf);
+        bincode::serialize_into(&mut buf, &rng).expect("Could not serialize");
+
+        let buf = buf.into_inner().unwrap();
+        let mut read = BufReader::new(&buf[..]);
+        let mut deserialized: XorShiftRng = bincode::deserialize_from(&mut read).expect("Could not deserialize");
+
+        assert_eq!(rng.x, deserialized.x);
+        assert_eq!(rng.y, deserialized.y);
+        assert_eq!(rng.z, deserialized.z);
+        assert_eq!(rng.w, deserialized.w);
+
+        for _ in 0..16 {
+            assert_eq!(rng.next_u64(), deserialized.next_u64());
+        }
+    }
+}


### PR DESCRIPTION
I was considering renaming this to `XorshiftRng`, but it's mostly of historical interest.

Reading the mentioned paper, this code is equivalent to the implementation in the summary, but this specific combination of constants does not appear elsewhere (there are four other combinations listed for the `[u32; 4]` configuration of state, but no indication how many exist).

@vks review? (The first commit is literally just a copy.)