### PR TITLE
Prepare release 0.0.1 of the parent crate and 0.1.0 of PCG and Xorshift crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2018-10-04
-- Pulled out of the Rand crate
+## [0.0.1] - 2018-10-04
+Initial release, including:
+
+- `rand_pcg` crate
+- `rand_xorshift` crate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "small-rngs"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -13,14 +13,42 @@ This repository houses a collection of random number generators for use with the
 
 All implementations are housed in sub-crates, as follows.
 
-### TODO (first sub-crate)
+### PCG
 
-- link to sub-directory
+Implements a selection of PCG random number generators.
+
+> PCG is a family of simple fast space-efficient statistically good algorithms
+> for random number generation. [Melissa O'Neill, Harvey Mudd College, 2014].
+
+- [Link to repository](https://github.com/rust-random/small-rngs/tree/master/rand_pcg)
+- [Link to crate](https://crates.io/crates/rand_pcg)
+
+### Xorshift
+
+Implements the Xorshift[^1] random number generator.
+
+[^1]: Marsaglia, George (July 2003).
+      ["Xorshift RNGs"](https://www.jstatsoft.org/v08/i14/paper).
+      *Journal of Statistical Software*. Vol. 8 (Issue 14).
+
+- [Link to repository](https://github.com/rust-random/small-rngs/tree/master/rand_xorshift)
+- [Link to crate](https://crates.io/crates/rand_xorshift)
 
 ## Features and dependencies
 
 Wherever possible, all sub-crates are `no_std` compatible, and depend only
 `core` and the [`rand_core`](https://crates.io/crates/rand-core) library.
+
+## Tests
+
+All PRNGs feature at minimum a "true values" test comparing output against
+test vectors provided as part of the specification, as well as "construction"
+tests testing reproducibility of supported seeding methods.
+
+## Benchmarks
+
+This parent crate includes benchmarks of all sub-crates, making benchmarking
+as simple as `cargo +nightly bench`.
 
 # License
 

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2018-??
-- Initial release
+## [0.1.0] - 2018-10-04
+Initial release, including:
+
+- `Lcg64Xsh32` aka `Pcg32`
+- `Mcg128Xsl64` aka `Pcg64Mcg`

--- a/rand_xorshift/README.md
+++ b/rand_xorshift/README.md
@@ -1,6 +1,6 @@
 # rand_xorshift
 
-[![Build Status](https://travis-ci.org/rust-random/small-rngs.svg?branch=master)](https://travis-ci.org/rust-random/small-rngs)
+[![Build Status](https://travis-ci.org/rust-random/small-rngs.svg)](https://travis-ci.org/rust-random/small-rngs)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/small-rngs?svg=true)](https://ci.appveyor.com/project/rust-random/small-rngs)
 [![Latest version](https://img.shields.io/crates/v/rand_xorshift.svg)](https://crates.io/crates/rand_xorshift)
 [![Documentation](https://docs.rs/rand_xorshift/badge.svg)](https://docs.rs/rand_xorshift)


### PR DESCRIPTION
The plan is to publish all three to crates.io tomorrow.

These have already had some review so hopefully there are no real issues.