### PR TITLE
rand_pcg: fix Serde dependency; prepare 0.1.1

### DIFF
--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2018-10-04
+- make `bincode` an explicit dependency when using Serde
+
 ## [0.1.0] - 2018-10-04
 Initial release, including:
 

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.1.1" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -25,11 +25,8 @@ serde1 = ["serde", "serde_derive", "bincode/i128"]
 rand_core = { version = "0.3", default-features=false }
 serde = { version = "1", optional = true }
 serde_derive = { version = "^1.0.38", optional = true }
-
-[dev-dependencies]
-# This is for testing serde, unfortunately we can't specify feature-gated dev
-# deps yet, see: https://github.com/rust-lang/cargo/issues/1596
-bincode = "1"
+# required for testing Serde, and we must depend on it to request i128 support
+bincode = { version = "1", optional = true }
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/rand_pcg/src/lib.rs
+++ b/rand_pcg/src/lib.rs
@@ -29,7 +29,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_pcg/0.1.0")]
+       html_root_url = "https://docs.rs/rand_pcg/0.1.1")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
Previously, serde1 depended on bincode/i128 where bincode
was a dev-dependency (used in internal tests but not otherwise).